### PR TITLE
Simplify flyout manager

### DIFF
--- a/bundles/statistics/statsgrid/FlyoutManager.js
+++ b/bundles/statistics/statsgrid/FlyoutManager.js
@@ -1,47 +1,31 @@
 Oskari.clazz.define('Oskari.statistics.statsgrid.FlyoutManager', function (instance, handler) {
     this.instance = instance;
     this.flyouts = {};
-    var loc = instance.getLocalization();
     Oskari.makeObservable(this);
     this._positionY = 5;
     this.handler = handler;
     this.searchHandler = this.handler.getSearchHandler();
     this.tableHandler = this.handler.getTableHandler();
     this.diagramHandler = this.handler.getDiagramHandler();
-    this.flyoutInfo = [
-        {
-            id: 'search',
-            title: loc.tile.search,
+    const locale = Oskari.getMsg.bind(null, 'StatsGrid');
+    this.flyouts = {
+        search: {
+            title: locale('tile.search'),
             controller: this.searchHandler.getController(),
             state: this.searchHandler.getState()
         },
-        {
-            id: 'table',
-            title: loc.tile.table,
+        table: {
+            title: locale('tile.table'),
             controller: this.tableHandler.getController(),
             state: this.tableHandler.getState()
         },
-        {
-            id: 'diagram',
-            title: loc.tile.diagram,
+        diagram: {
+            title: locale('tile.diagram'),
             controller: this.diagramHandler.getController(),
             state: this.diagramHandler.getState()
         }
-    ];
+    };
 }, {
-    init: function () {
-        if (Object.keys(this.flyouts).length) {
-            // already initialized
-            return;
-        }
-
-        this.flyoutInfo.forEach((info) => {
-            this.flyouts[info.id] = {
-                controller: info.controller,
-                state: info.state
-            };
-        });
-    },
     open: function (type) {
         const flyout = this.flyouts[type];
         if (!flyout) {
@@ -49,7 +33,9 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.FlyoutManager', function (insta
         }
         flyout.controller.toggleFlyout(true, () => this.trigger('hide', type));
         this.trigger('show', type);
-        this.flyoutInfo.filter(info => info.id !== type).forEach(info => this.hide(info.id));
+        Object.keys(this.flyouts)
+            .filter(id => id !== type)
+            .forEach(type => this.hide(type));
     },
     hide: function (type) {
         const flyout = this.flyouts[type];
@@ -75,6 +61,15 @@ Oskari.clazz.define('Oskari.statistics.statsgrid.FlyoutManager', function (insta
     },
     getFlyout: function (type) {
         return this.flyouts[type];
+    },
+    getTileOptions: function () {
+        return Object.keys(this.flyouts)
+            .map(id => {
+                return {
+                    id,
+                    label: this.flyouts[id].title
+                };
+            });
     },
     tileAttached: function () {
         if (this.handler.getState().indicators?.length < 1) {

--- a/bundles/statistics/statsgrid/FlyoutManager.js
+++ b/bundles/statistics/statsgrid/FlyoutManager.js
@@ -1,4 +1,4 @@
-Oskari.clazz.define('Oskari.statistics.statsgrid.FlyoutManager', function (instance, service, handler) {
+Oskari.clazz.define('Oskari.statistics.statsgrid.FlyoutManager', function (instance, handler) {
     this.instance = instance;
     this.flyouts = {};
     var loc = instance.getLocalization();

--- a/bundles/statistics/statsgrid/Tile.js
+++ b/bundles/statistics/statsgrid/Tile.js
@@ -1,0 +1,162 @@
+
+Oskari.clazz.define('Oskari.statistics.statsgrid.Tile', function (instance, service) {
+    this.instance = instance;
+    this.sb = this.instance.getSandbox();
+    this.loc = this.instance.getLocalization();
+    this.statsService = service;
+    this.container = null;
+    this.template = null;
+    this._tileExtensions = {};
+    this.flyoutManager = null;
+    this._attached = false;
+    this._templates = {
+        extraSelection: ({ id, label }) =>
+            `<div class="statsgrid-functionality ${id}" data-view="${id}">
+                <div class="icon"></div>
+                <div class="text">${label}</div>
+            </div>`
+    };
+}, {
+    /**
+     * @method getName
+     * @return {String} the name for the component
+     */
+    getName: function () {
+        return 'Oskari.statistics.statsgrid.Tile';
+    },
+    /**
+     * @method getTitle
+     * @return {String} localized text for the title of the tile
+     */
+    getTitle: function () {
+        return this.loc.flyout.title;
+    },
+    /**
+     * @method getDescription
+     * @return {String} localized text for the description of the tile
+     */
+    getDescription: function () {
+        return this.instance.getLocalization('desc');
+    },
+    /**
+     * @method setEl
+     * @param {Object} el
+     *      reference to the container in browser
+     * @param {Number} width
+     *      container size(?) - not used
+     * @param {Number} height
+     *      container size(?) - not used
+     *
+     * Interface method implementation
+     */
+    setEl: function (el, width, height) {
+        this.container = jQuery(el);
+    },
+    /**
+     * @method startPlugin
+     * Interface method implementation, calls #createUi()
+     */
+    startPlugin: function () {
+        this._addTileStyleClasses();
+    },
+    setupTools: function (flyoutManager) {
+        const tpl = this._templates.extraSelection;
+        this.flyoutManager = flyoutManager;
+
+        flyoutManager.getTileOptions().forEach((flyout) => {
+            const tileExtension = jQuery(tpl(flyout));
+            this.extendTile(tileExtension, flyout.id);
+            tileExtension.on('click', function (event) {
+                event.stopPropagation();
+                flyoutManager.toggle(flyout.id);
+            });
+        });
+
+        this.hideExtensions();
+
+        this.flyoutManager.on('show', (flyout) => this.toggleExtension(flyout, true));
+        this.flyoutManager.on('hide', (flyout) => this.toggleExtension(flyout, false));
+    },
+    /**
+     * Adds a class for the tile so we can programmatically identify which functionality the tile controls.
+     */
+    _addTileStyleClasses: function () {
+        var isContainer = !!((this.container && this.instance.mediator));
+        var isBundleId = !!((isContainer && this.instance.mediator.bundleId));
+        var isInstanceId = !!((isContainer && this.instance.mediator.instanceId));
+
+        if (isInstanceId && !this.container.hasClass(this.instance.mediator.instanceId)) {
+            this.container.addClass(this.instance.mediator.instanceId);
+        }
+        if (isBundleId && !this.container.hasClass(this.instance.mediator.bundleId)) {
+            this.container.addClass(this.instance.mediator.bundleId);
+        }
+    },
+    /**
+     * @method stopPlugin
+     * Interface method implementation, clears the container
+     */
+    stopPlugin: function () {
+        this.container.empty();
+    },
+    /**
+     * Adds an extra option on the tile
+     */
+    extendTile: function (el, type) {
+        var container = this.container.append(el);
+        var extension = container.find(el);
+        this._tileExtensions[type] = extension;
+    },
+    toggleExtension: function (flyout, shown) {
+        var element = this.getExtensions()[flyout];
+        if (!element) {
+            // flyout not part of tile
+            return;
+        }
+
+        if (!shown) {
+            element.removeClass('material-selected');
+            return;
+        }
+        element.addClass('material-selected');
+    },
+    /**
+     * Hides all the extra options (used when tile is "deactivated")
+     */
+    hideExtensions: function () {
+        var extraOptions = this.getExtensions();
+        Object.keys(extraOptions).forEach(function (key) {
+            extraOptions[key].addClass('hidden');
+        });
+        this._attached = false;
+        this.flyoutManager.tileClosed();
+    },
+    /**
+     * Shows the tile extra options (when tile is activated)
+     * @return {[type]} [description]
+     */
+    showExtensions: function () {
+        var extraOptions = this.getExtensions();
+        Object.keys(extraOptions).forEach(function (key) {
+            extraOptions[key].removeClass('hidden');
+        });
+        this._attached = true;
+        this.flyoutManager.tileAttached();
+    },
+    isAttached: function () {
+        return this._attached;
+    },
+    /**
+     * [getExtensions description]
+     * @return {Object} with key as flyout id and value of DOM-element for the extra option in the tile
+     */
+    getExtensions: function () {
+        return this._tileExtensions;
+    }
+}, {
+    /**
+     * @property {String[]} protocol
+     * @static
+     */
+    'protocol': ['Oskari.userinterface.Tile']
+});

--- a/bundles/statistics/statsgrid/instance.js
+++ b/bundles/statistics/statsgrid/instance.js
@@ -1,7 +1,7 @@
 import { MyIndicatorsHandler } from './handler/MyIndicatorsHandler';
 import { MyIndicatorsTab } from './MyIndicatorsTab';
 import './FlyoutManager.js';
-import '../statsgrid2016/Tile.js';
+import './Tile.js';
 import './service/StatisticsService.js';
 import './service/SeriesService.js';
 import '../statsgrid2016/service/ClassificationService.js';
@@ -91,7 +91,6 @@ Oskari.clazz.define(
 
             // initialize flyoutmanager
             this.flyoutManager = Oskari.clazz.create('Oskari.statistics.statsgrid.FlyoutManager', this, this.stateHandler);
-            this.flyoutManager.init();
             this.getTile().setupTools(this.flyoutManager);
 
             this.togglePlugin = Oskari.clazz.create('Oskari.statistics.statsgrid.TogglePlugin', this.getFlyoutManager(), conf.location?.classes);

--- a/bundles/statistics/statsgrid/instance.js
+++ b/bundles/statistics/statsgrid/instance.js
@@ -90,7 +90,7 @@ Oskari.clazz.define(
             this.stateHandler.addRegionset(conf.regionsets);
 
             // initialize flyoutmanager
-            this.flyoutManager = Oskari.clazz.create('Oskari.statistics.statsgrid.FlyoutManager', this, statsService, this.stateHandler);
+            this.flyoutManager = Oskari.clazz.create('Oskari.statistics.statsgrid.FlyoutManager', this, this.stateHandler);
             this.flyoutManager.init();
             this.getTile().setupTools(this.flyoutManager);
 

--- a/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
+++ b/bundles/statistics/statsgrid/view/search/SearchFlyout.jsx
@@ -144,7 +144,6 @@ const SearchFlyout = ({ state, controller }) => {
 };
 
 export const showSearchFlyout = (state, controller, onClose) => {
-
     const title = <Message bundleKey={BUNDLE_KEY} messageKey='tile.search' />;
     const controls = showFlyout(
         title,
@@ -162,5 +161,5 @@ export const showSearchFlyout = (state, controller, onClose) => {
                 <SearchFlyout state={state} controller={controller} />
             </LocaleProvider>
         )
-    }
-}
+    };
+};


### PR DESCRIPTION
Remove the array of flyouts and loop Object.keys() to get similar functionality. Slight change required for Tile.js so made a copy of it from statsgrid2016.