### PR TITLE
We don't need to reset active regionset

### DIFF
--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -206,7 +206,8 @@ class StatisticsController extends StateHandler {
             activeRegion: null,
             indicators: [],
             regions: [],
-            lastSelectedClassification: null
+            lastSelectedClassification: null,
+            indicatorData: {}
         });
         const eventBuilder = Oskari.eventBuilder('StatsGrid.StateChangedEvent');
         this.sandbox.notifyAll(eventBuilder(true));

--- a/bundles/statistics/statsgrid/handler/StatisticsHandler.js
+++ b/bundles/statistics/statsgrid/handler/StatisticsHandler.js
@@ -204,11 +204,9 @@ class StatisticsController extends StateHandler {
         this.updateState({
             activeIndicator: null,
             activeRegion: null,
-            activeRegionset: null,
             indicators: [],
             regions: [],
-            lastSelectedClassification: null,
-            indicatorData: {}
+            lastSelectedClassification: null
         });
         const eventBuilder = Oskari.eventBuilder('StatsGrid.StateChangedEvent');
         this.sandbox.notifyAll(eventBuilder(true));


### PR DESCRIPTION
If there's only one regionset available the user can't reselect regionset (control not shown) -> don't reset it.