### PR TITLE
Update state handling for layerswipe/embedded maps

### DIFF
--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -11,7 +11,7 @@ Oskari.registerLocalization(
                 "serviceDescription": "Fill in the url and version for the service",
                 "layersDescription": "These are the layers that are available in the service. Please select one to add as a map layer",
                 "details": "Map layer details",
-                "toggleFlatView": "Flat view",
+                "toggleFlatView": "List view",
                 "toggleTreeView": "Tree view"
 
             },

--- a/bundles/admin/admin-layereditor/resources/locale/en.js
+++ b/bundles/admin/admin-layereditor/resources/locale/en.js
@@ -10,7 +10,10 @@ Oskari.registerLocalization(
                 "typeDescription": "Select the type of the service for layer you are adding",
                 "serviceDescription": "Fill in the url and version for the service",
                 "layersDescription": "These are the layers that are available in the service. Please select one to add as a map layer",
-                "details": "Map layer details"
+                "details": "Map layer details",
+                "toggleFlatView": "Flat view",
+                "toggleTreeView": "Tree view"
+
             },
             "layertype": {
                 "wmslayer": "WMS",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -10,7 +10,9 @@ Oskari.registerLocalization(
                 "typeDescription": "Valitse lisättävän rajapinnan tyyppi",
                 "serviceDescription": "Syötä lisättävän rajapinnan osoite ja versionumero",
                 "layersDescription": "Valitse rajapinnasta löytyvistä tasoista se jonka haluat lisätä karttatasoksi",
-                "details": "Tason tiedot"
+                "details": "Tason tiedot",
+                "toggleFlatView": "Lista",
+                "toggleTreeView": "Puunäkymä"
             },
             "layertype": {
                 "wmslayer": "WMS",

--- a/bundles/admin/admin-layereditor/resources/locale/fi.js
+++ b/bundles/admin/admin-layereditor/resources/locale/fi.js
@@ -11,7 +11,7 @@ Oskari.registerLocalization(
                 "serviceDescription": "Syötä lisättävän rajapinnan osoite ja versionumero",
                 "layersDescription": "Valitse rajapinnasta löytyvistä tasoista se jonka haluat lisätä karttatasoksi",
                 "details": "Tason tiedot",
-                "toggleFlatView": "Lista",
+                "toggleFlatView": "Listanäkymä",
                 "toggleTreeView": "Puunäkymä"
             },
             "layertype": {

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -11,8 +11,8 @@ Oskari.registerLocalization(
                 "serviceDescription": "Ange adress och versionnummer för gränssnittet du vill lägga till",
                 "layersDescription": "Från lagren i gränssnittet väljer du det du vill lägga till som kartlager",
                 "details": "Uppgifter om kartlagret",
-                "toggleFlatView": "*SV*Lattana näkymä",
-                "toggleTreeView": "*SV*Puunäkymä"
+                "toggleFlatView": "Listvy",
+                "toggleTreeView": "Trädvy"
 
             },
             "layertype": {

--- a/bundles/admin/admin-layereditor/resources/locale/sv.js
+++ b/bundles/admin/admin-layereditor/resources/locale/sv.js
@@ -10,7 +10,10 @@ Oskari.registerLocalization(
                 "typeDescription": "Välj vilken typ av gränssnitt du vill lägga till",
                 "serviceDescription": "Ange adress och versionnummer för gränssnittet du vill lägga till",
                 "layersDescription": "Från lagren i gränssnittet väljer du det du vill lägga till som kartlager",
-                "details": "Uppgifter om kartlagret"
+                "details": "Uppgifter om kartlagret",
+                "toggleFlatView": "*SV*Lattana näkymä",
+                "toggleTreeView": "*SV*Puunäkymä"
+
             },
             "layertype": {
                 "wmslayer": "WMS",

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
@@ -2,9 +2,12 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { List, ListItem, Tooltip, Message, Confirm, Button } from 'oskari-ui';
+
 import { LocaleConsumer } from 'oskari-ui/util';
 import { LayerCapabilitiesFilter } from './LayerCapabilitiesFilter';
 import { CheckCircleTwoTone, QuestionCircleTwoTone, WarningTwoTone } from '@ant-design/icons';
+
+const LOCALIZATION_BUNDLE_ID = 'admin-layereditor';
 
 export const StyledListItem = styled(ListItem)`
     :hover {
@@ -23,6 +26,10 @@ const PaddedItemContainer = styled('div')`
     margin-left: ${props => props.depth}vw;
 `;
 
+const ToggleButton = styled(Button)`
+    margin: 1vh 0;
+`;
+
 const LayerCapabilitiesListing = ({ capabilities = {}, onSelect = () => {}, getMessage }) => {
     const [filter, setfilter] = useState('');
     const [treeView, setTreeview] = useState(false);
@@ -31,17 +38,21 @@ const LayerCapabilitiesListing = ({ capabilities = {}, onSelect = () => {}, getM
     if (treeView) {
         return (
             <React.Fragment>
-                <Button onClick={() => setTreeview(!treeView)}>toggle flat view</Button>
+                <ToggleButton type={'primary'} onClick={() => setTreeview(!treeView)}>
+                    <Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey={'wizard.toggleFlatView'}/>
+                </ToggleButton>
                 <LayerCapabilitiesTreeView capabilities={capabilities} onSelect={onSelect} getMessage={getMessage}/>
             </React.Fragment>);
     }
     return (
         <React.Fragment>
-            <Button onClick={() => setTreeview(!treeView)}>toggle treeview</Button>
             <LayerCapabilitiesFilter
                 placeholder="Filter layers"
                 filter={filter}
                 onChange={(value) => setfilter(value)}/>
+            <ToggleButton type={'primary'} onClick={() => setTreeview(!treeView)}>
+                <Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey={'wizard.toggleTreeView'}/>
+            </ToggleButton>
             <List dataSource={layers} rowKey="name" renderItem={item => getItem(onSelect, item, getMessage)}></List>
         </React.Fragment>);
 };
@@ -79,7 +90,6 @@ LayerCapabilitiesTreeView.propTypes = {
 
 const contextWrap = LocaleConsumer(LayerCapabilitiesListing);
 export { contextWrap as LayerCapabilitiesListing };
-
 
 /**
  * Processes a layer list to be rendered based on capabilities

--- a/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
+++ b/bundles/admin/admin-layereditor/view/LayerWizard/LayerCapabilitiesListing.jsx
@@ -33,14 +33,18 @@ const ToggleButton = styled(Button)`
 const LayerCapabilitiesListing = ({ capabilities = {}, onSelect = () => {}, getMessage }) => {
     const [filter, setfilter] = useState('');
     const [treeView, setTreeview] = useState(false);
+    const canHaveTreeView = !!capabilities?.structure;
     const allLayers = prepareData(capabilities);
     const layers = sortLayers(filterLayers(allLayers, filter));
+
     if (treeView) {
         return (
             <React.Fragment>
+                { canHaveTreeView &&
                 <ToggleButton type={'primary'} onClick={() => setTreeview(!treeView)}>
                     <Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey={'wizard.toggleFlatView'}/>
                 </ToggleButton>
+                }
                 <LayerCapabilitiesTreeView capabilities={capabilities} onSelect={onSelect} getMessage={getMessage}/>
             </React.Fragment>);
     }
@@ -50,9 +54,11 @@ const LayerCapabilitiesListing = ({ capabilities = {}, onSelect = () => {}, getM
                 placeholder="Filter layers"
                 filter={filter}
                 onChange={(value) => setfilter(value)}/>
-            <ToggleButton type={'primary'} onClick={() => setTreeview(!treeView)}>
-                <Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey={'wizard.toggleTreeView'}/>
-            </ToggleButton>
+            { canHaveTreeView &&
+                <ToggleButton type={'primary'} onClick={() => setTreeview(!treeView)}>
+                    <Message bundleKey={LOCALIZATION_BUNDLE_ID} messageKey={'wizard.toggleTreeView'}/>
+                </ToggleButton>
+            }
             <List dataSource={layers} rowKey="name" renderItem={item => getItem(onSelect, item, getMessage)}></List>
         </React.Fragment>);
 };

--- a/bundles/framework/divmanazer/resources/scss/divman.scss
+++ b/bundles/framework/divmanazer/resources/scss/divman.scss
@@ -21,22 +21,23 @@ body {
 /* flyout toolbar */
 
 .oskari-root-el > nav {
-      &.show-scroll-icon {
+    &.show-scroll-icon {
         .scroll-indicator {
             display: flex;
         }
         .scroll-icon {
-          animation:flash 2s 5 linear;
+            animation:flash 2s 5 linear;
         }
-      }
-      @keyframes flash {
+        }
+        @keyframes flash {
         0%, 100% {
-          opacity: 0.6;
+            opacity: 0.6;
         }
         50% {
-          opacity: .1;
+            opacity: .1;
         }
-      }
+    }
+    padding-bottom: 35px;
 }
 
 .oskari-flyoutheading {

--- a/bundles/framework/printout/PrintoutHandler.js
+++ b/bundles/framework/printout/PrintoutHandler.js
@@ -158,7 +158,8 @@ class UIHandler extends StateHandler {
             pageTitle: this.state.mapTitle,
             pageScale: this.state.showScale,
             pageDate: this.state.showDate,
-            pageTimeSeriesTime: this.state.showTimeSeriesDate
+            pageTimeSeriesTime: this.state.showTimeSeriesDate,
+            lang: Oskari.getLang()
         };
 
         if (this.state.scale) {

--- a/bundles/framework/printout/PrintoutHandler.js
+++ b/bundles/framework/printout/PrintoutHandler.js
@@ -159,12 +159,15 @@ class UIHandler extends StateHandler {
             pageScale: this.state.showScale,
             pageDate: this.state.showDate,
             pageTimeSeriesTime: this.state.showTimeSeriesDate,
-            lang: Oskari.getLang()
+            lang: Oskari.getLang(),
+            coordinateSRS: this.mapModule.getProjection()
         };
 
         if (this.state.scale) {
             params.scaleText = '1:' + this.state.scale;
         }
+
+        // check if other target crs setting beside default has been selected
         if (this.state.showCoordinates) {
             params.coordinateInfo = this.state.coordinatePosition;
             params.coordinateSRS = this.state.coordinateProjection === 'map' ? this.mapModule.getProjection() : this.state.coordinateProjection;
@@ -256,7 +259,8 @@ class UIHandler extends StateHandler {
             srs: map.getSrsName(),
             coord: `${map.getX()}_${map.getY()}`,
             mapLayers,
-            scaledWidth: PREVIEW_SCALED_WIDTH
+            scaledWidth: PREVIEW_SCALED_WIDTH,
+            coordinateSRS: this.mapModule.getProjection()
         };
         if (layer.hasTimeseries()) {
             params.time = this._getTimeParam();

--- a/bundles/framework/printout/resources/locale/en.js
+++ b/bundles/framework/printout/resources/locale/en.js
@@ -59,7 +59,7 @@ Oskari.registerLocalization(
                     "printLabel": "Time series time"
                 },
                 "coordinates": {
-                    "label": "Show coordinates",
+                    "label": "Include coordinates",
                     "position": {
                         "label": "Location",
                         "options": {

--- a/bundles/framework/printout/resources/locale/sv.js
+++ b/bundles/framework/printout/resources/locale/sv.js
@@ -13,10 +13,10 @@ Oskari.registerLocalization(
                 "label": "Storlek",
                 "tooltip": "Välj utskriftsstorlek. Uppdateringar visas i förhandsgranskningsbilden.",
                 "options": {
-                    "A4": "A4 porträtt",                        
+                    "A4": "A4 porträtt",
                     "A4_Landscape": "A4 landskap",
                     "A3": "A3 porträtt",
-                    "A3_Landscape": "A3 landskap"        
+                    "A3_Landscape": "A3 landskap"
                 }
             },
             "preview": {
@@ -59,7 +59,7 @@ Oskari.registerLocalization(
                     "printLabel": "Tidpunkten av tidsserien"
                 },
                 "coordinates": {
-                    "label": "Visa koordinaterna",
+                    "label": "Visa koordinater",
                     "position": {
                         "label": "Placering",
                         "options": {

--- a/bundles/framework/printout/view/AdditionalSettings.jsx
+++ b/bundles/framework/printout/view/AdditionalSettings.jsx
@@ -98,31 +98,31 @@ export const AdditionalSettings = ({ controller, state }) => {
                     </StyledCheckbox>
                 )}
                 {/* TODO: Enable once Coordinates are implemented to back end */}
-                {/* <StyledCheckbox
+                { <StyledCheckbox
                     checked={state.showCoordinates}
                     onChange={(e) => controller.updateField('showCoordinates', e.target.checked)}
                     disabled={state.format !== 'application/pdf'}
                 >
                     <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.content.coordinates.label' />
-                </StyledCheckbox> */}
+                </StyledCheckbox> }
             </FormGroup>
             {state.showCoordinates && (
                 <CoordinateOptions>
                     <FormGroup>
-                            <Label>
-                                <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.content.coordinates.position.label' />
-                            </Label>
-                            <Radio.Group
-                                value={state.coordinatePosition}
-                                onChange={(e) => controller.updateField('coordinatePosition', e.target.value)}
-                                disabled={state.format !== 'application/pdf'}
-                            >
-                                {COORDINATE_POSITIONS.map(pos => (
-                                    <Radio.Choice value={pos} key={pos}>
-                                        <Message bundleKey={BUNDLE_KEY} messageKey={`BasicView.content.coordinates.position.options.${pos}`} />
-                                    </Radio.Choice>
-                                ))}
-                            </Radio.Group>
+                        <Label>
+                            <Message bundleKey={BUNDLE_KEY} messageKey='BasicView.content.coordinates.position.label' />
+                        </Label>
+                        <Radio.Group
+                            value={state.coordinatePosition}
+                            onChange={(e) => controller.updateField('coordinatePosition', e.target.value)}
+                            disabled={state.format !== 'application/pdf'}
+                        >
+                            {COORDINATE_POSITIONS.map(pos => (
+                                <Radio.Choice value={pos} key={pos}>
+                                    <Message bundleKey={BUNDLE_KEY} messageKey={`BasicView.content.coordinates.position.options.${pos}`} />
+                                </Radio.Choice>
+                            ))}
+                        </Radio.Group>
                     </FormGroup>
                     <FormGroup>
                         <Label>

--- a/bundles/mapping/layerswipe/handler/SwipeToolHandler.js
+++ b/bundles/mapping/layerswipe/handler/SwipeToolHandler.js
@@ -7,25 +7,35 @@ class UIHandler extends StateHandler {
         this.sandbox = tool.getSandbox();
         this.setState({
             autoStart: false,
-            hideUI: false
+            noUI: false
         });
     };
+
     init (pluginConfig) {
         this.updateState({
-            ...pluginConfig
+            ...pluginConfig.conf,
+            autoStart: pluginConfig?.state?.active,
+            noUI: pluginConfig?.conf?.noUI
         });
     }
 
+    syncState () {
+        // required to sync state to plugin on startup and restore the state of the embedded map
+        const { autoStart, noUI } = this.getState();
+        this.setAutoStart(autoStart);
+        this.setHideUI(noUI);
+    }
+
     clearState () {
-        // plugin is created again on startup, so it's state doesn't need to be cleare
+        // plugin is created again on startup, so it's state doesn't need to be cleared
         this.setState({
             autoStart: false,
-            hideUI: false
+            noUI: false
         });
     }
 
     setAutoStart (value) {
-        this.tool.getPlugin().setAutoStart(value);
+        this.tool.getPlugin().toggleToolState(!!value);
         this.updateConfig2State();
     }
 
@@ -35,9 +45,9 @@ class UIHandler extends StateHandler {
     }
 
     updateConfig2State () {
-        const newConfig = this.tool?.getPlugin()?.getConfig() || {};
         this.updateState({
-            ...newConfig
+            autoStart: !!this.tool?.getPlugin()?.isActive(),
+            noUI: !!this.tool?.getPlugin()?.hasUI()
         });
     }
 }

--- a/bundles/mapping/layerswipe/plugin/LayerSwipePlugin.js
+++ b/bundles/mapping/layerswipe/plugin/LayerSwipePlugin.js
@@ -16,7 +16,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlug
      * @static
      */
     function (config) {
-        var me = this;
+        const me = this;
         me._config = config || {};
         me._clazz =
             'Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlugin';
@@ -26,29 +26,29 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlug
 
         me.initialSetup = true;
         me.templates = {};
-        me._active = this.getConfig()?.autoStart || false;
     }, {
-        _toggleToolState: function (active) {
-            this.getInstance()?.setActive(active);
-            this._active = active;
-            this.refresh();
-        },
-
         /**
          * @private @method _initImpl
          * Interface method for the module protocol. Initializes the request
          * handlers/templates.
          */
         _initImpl: function () {
-            var me = this;
-            me._loc = Oskari.getLocalization('LayerSwipe', Oskari.getLang() || Oskari.getDefaultLanguage(), true);
-            me.templates.main = jQuery(
-                '<div class="mapplugin layerswipe"></div>');
-            if (me._active) {
-                me._toggleToolState(true);
-            }
+            this._title = Oskari.getMsg('LayerSwipe', 'toolLayerSwipe');
+            this.templates.main = jQuery('<div class="mapplugin layerswipe"></div>');
         },
-        resetUI: function () {},
+        _startPluginImpl: function () {
+            this.addToPluginContainer(this._createControlElement());
+            this.refresh();
+            return true;
+        },
+        toggleToolState: function (active) {
+            this.getInstance()?.setActive(active);
+        },
+        isActive: function () {
+            return !!this.getInstance()?.isActive();
+        },
+        resetUI: function () {
+        },
         getInstance: function () {
             // we only need instance here since the flyout is operated by the instance
             // TODO: we should move the flyout related code to this plugin
@@ -66,18 +66,14 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlug
             }
             return this._instance;
         },
-        setAutoStart: function (value) {
-            const old = this.getConfig();
-            this.setConfig({
-                ...old,
-                autoStart: value
-            });
+        hasUI: function () {
+            return !this.getConfig()?.noUI;
         },
         setHideUI: function (value) {
             const old = this.getConfig();
             this.setConfig({
                 ...old,
-                hideUI: value
+                noUI: value
             });
         },
         /**
@@ -94,7 +90,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlug
 
         teardownUI: function () {
             // remove old element
-            this._toggleToolState(false);
+            this.toggleToolState(false);
             this.removeFromPluginContainer(this.getElement());
         },
 
@@ -104,8 +100,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlug
          * @param  {Boolean} mapInMobileMode is map in mobile mode
          * @param {Boolean} forced application has started and ui should be rendered with assets that are available
          */
+        /*
         redrawUI: function (mapInMobileMode, forced) {
-            if (!this.isVisible() || !this.isEnabled()) {
+            if (!this.hasUI() || !this.isEnabled()) {
                 // no point in drawing the ui if we are not visible
                 return;
             }
@@ -115,9 +112,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlug
             this.refresh();
             this.addToPluginContainer(this._element);
         },
-
+*/
         refresh: function () {
-            let el = this.getElement();
+            const el = this.getElement();
             if (!el) {
                 return;
             }
@@ -126,10 +123,10 @@ Oskari.clazz.define('Oskari.mapframework.bundle.layerswipe.plugin.LayerSwipePlug
                 <MapModuleButton
                     className='t_layerswipe'
                     icon={<SwipeIcon />}
-                    visible={!this.getConfig()?.hideUI}
-                    title={this._loc.toolLayerSwipe}
-                    onClick={(e) => this._toggleToolState(!this._active)}
-                    iconActive={this._active ? true : false}
+                    visible={this.hasUI()}
+                    title={this._title}
+                    onClick={(e) => this.toggleToolState(!this.isActive())}
+                    iconActive={this.isActive()}
                     position={this.getLocation()}
                 />,
                 el[0]

--- a/bundles/mapping/layerswipe/publisher/SwipeTool.js
+++ b/bundles/mapping/layerswipe/publisher/SwipeTool.js
@@ -11,6 +11,7 @@ class SwipeTool extends AbstractPublisherTool {
         this.group = 'additional';
         this.handler = new SwipeToolhandler(this);
     }
+
     getTool () {
         return {
             id: SWIPE_ID,
@@ -18,34 +19,42 @@ class SwipeTool extends AbstractPublisherTool {
             config: this.state.pluginConfig || {}
         };
     }
+
     getComponent () {
         return {
             component: SwipeToolComponent,
             handler: this.handler
         };
     }
+
     init (data) {
-        const configuration = data?.configuration?.layerswipe?.conf;
+        const configuration = data?.configuration?.layerswipe || {};
         // restore state to handler -> passing init data to it
         this.handler.init(configuration);
-        if (configuration) {
-            this.storePluginConf(configuration);
+        if (configuration.conf) {
+            this.storePluginConf(configuration.conf);
             this.setEnabled(true);
         }
     }
+
     getValues () {
         if (!this.isEnabled()) {
             return null;
         }
+        const { autoStart = false } = this.handler.getState();
         const value = {
             configuration: {
                 layerswipe: {
-                    conf: this.getPlugin().getConfig()
+                    conf: this.tool?.getPlugin()?.getConfig() || {},
+                    state: {
+                        active: autoStart
+                    }
                 }
             }
         };
         return value;
     }
+
     stop () {
         super.stop();
         this.handler.clearState();

--- a/bundles/mapping/layerswipe/publisher/SwipeToolComponent.jsx
+++ b/bundles/mapping/layerswipe/publisher/SwipeToolComponent.jsx
@@ -30,7 +30,7 @@ const HideUISelect = ({ state, controller }) => {
     return (
         <Checkbox
             className='t_swipe_hide_plugin'
-            checked={state.hideUI}
+            checked={state.noUI}
             onChange={(e) => controller.setHideUI(e.target.checked)}
         >
             <Message bundleKey="Publisher2" messageKey='BasicView.noUI' />

--- a/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
+++ b/bundles/mapping/mapmodule/plugin/markers/MarkersPlugin.ol.js
@@ -161,7 +161,7 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
          * @private
          * @param  {Oskari.mapframework.bundle.mapmodule.event.MapClickedEvent} event map click
          */
-        _mapClick: function (event) {
+        _mapClick: async function (event) {
             this.keepToolActive = true;
             if (this.markerPopupControls) {
                 this.closeMarkerPopup();
@@ -176,15 +176,36 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
                         .forEach((feature) => this._markerClicked(feature.getId())));
                 return;
             }
+            // get markers from layer by pixel so we get result based on visualization and not the coordinate for the point
+            const pixels = [event.getMouseX(), event.getMouseY()];
+            const features = await this.getMarkersLayer().getFeatures(pixels);
+            for (const feature of features) {
+                this._markerClicked(feature.getId());
+            }
+
+            if (!this._showAddMarkerPopupOnMapClick) {
+                return;
+            }
+
             // adding a marker
             const { lon, lat } = event.getLonLat();
-            const coord = [lon, lat];
             this._showAddMarkerPopupOnMapClick = false;
-            const onAdd = style => {
+            const onAdd = (style, marker) => {
+                const coord = marker ? [marker.x, marker.y] : [lon, lat];
                 this.popupCleanup();
-                this._addMarkerFromPopup(coord, style);
+                this._addMarkerFromPopup(coord, style, marker?.id);
             };
-            this.popupControls = showAddMarkerPopup(onAdd, this.popupCleanup);
+            const onDelete = (marker) => {
+                this.popupCleanup();
+                this.removeMarkers(marker.id);
+            };
+
+            if (features.length > 0) {
+                const markerData = this._featureToMarkerData(features[0]);
+                this.popupControls = showAddMarkerPopup(onAdd, onDelete, this.popupCleanup, markerData);
+            } else {
+                this.popupControls = showAddMarkerPopup(onAdd, onDelete, this.popupCleanup);
+            }
         },
         /**
          * Called when a marker has been clicked.
@@ -345,8 +366,8 @@ Oskari.clazz.define('Oskari.mapframework.mapmodule.MarkersPlugin',
             }
             return style;
         },
-        _addMarkerFromPopup: function (coord, style) {
-            const id = ID_PREFIX + Oskari.getSeq(this.getName()).nextVal();
+        _addMarkerFromPopup: function (coord, style, existingId) {
+            const id = existingId || ID_PREFIX + Oskari.getSeq(this.getName()).nextVal();
             const { image, text } = style;
             const { fill, shape, size } = image;
             const styleData = {

--- a/bundles/mapping/mapmodule/plugin/markers/view/MarkersForm.jsx
+++ b/bundles/mapping/mapmodule/plugin/markers/view/MarkersForm.jsx
@@ -20,10 +20,19 @@ const getMarkerStyle = state => {
     return style;
 };
 
-const Form = ({ onAdd, onClose }) => {
+const Form = ({ onAdd, onDelete, onClose, marker }) => {
     const [state, setState] = useState({
-        style: DEFAULT_STYLE,
-        msg: ''
+        style: marker ? {
+            ...DEFAULT_STYLE,
+            image: {
+                shape: marker.shape,
+                size: marker.size,
+                fill: {
+                    color: `#${marker.color}`
+                }
+            }
+        } : DEFAULT_STYLE,
+        msg: marker ? marker.msg : ''
     });
 
     const updateStyle = (style) => setState({ ...state, style });
@@ -34,7 +43,7 @@ const Form = ({ onAdd, onClose }) => {
             <Tooltip title={getMessage('form.message.label')}>
                 <TextInput
                     placeholder={ Oskari.getMsg(BUNDLE_KEY, `plugin.${PLUGIN_NAME}.form.message.label`) }
-                    value={ state.text }
+                    value={ state.msg }
                     onChange={ (event) => updateMsg(event.target.value) }
                 />
             </Tooltip>
@@ -45,8 +54,14 @@ const Form = ({ onAdd, onClose }) => {
                 geometryType = {GEOMETRY_TYPE}
             />
             <ButtonContainer>
+                {marker && (
+                    <SecondaryButton
+                        type='delete'
+                        onClick={() => onDelete(marker)}
+                    />
+                )}
                 <SecondaryButton type='close' onClick={onClose}/>
-                <PrimaryButton type='add' onClick={() => onAdd(getMarkerStyle(state)) }/>
+                <PrimaryButton type={marker ? 'save' : 'add'} onClick={() => onAdd(getMarkerStyle(state), marker) }/>
             </ButtonContainer>
         </Content>
     );
@@ -55,9 +70,9 @@ Form.propTypes = {
     onAdd: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired
 };
-export const showAddMarkerPopup = (onAdd, onClose) => {
+export const showAddMarkerPopup = (onAdd, onDelete, onClose, marker) => {
     const content = (
-        <Form onAdd= { onAdd } onClose={ onClose }/>
+        <Form onAdd= { onAdd } onDelete= { onDelete } onClose={ onClose } marker={marker} />
     );
     return showPopup(getMessage('title'), content, onClose, { id: PLUGIN_NAME });
 };

--- a/bundles/mapping/mapmodule/plugin/pinchzoomreset/PinchZoomResetPlugin.js
+++ b/bundles/mapping/mapmodule/plugin/pinchzoomreset/PinchZoomResetPlugin.js
@@ -55,7 +55,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapmodule.plugin.PinchZoomResetP
          * @return {Boolean} true if page is zoomed in
          */
         isZoomedIn: function () {
-            return window.innerWidth !== window.visualViewport.width || window.innerHeight !== window.visualViewport.height;
+            return parseInt(window.innerWidth) !== parseInt(window.visualViewport.width) || parseInt(window.innerHeight) !== parseInt(window.visualViewport.height);
         },
 
         /**


### PR DESCRIPTION
Merging develop to this so GH shows more changes than there actually is. With the actual changes the primary layerswipe enabled on embedded maps works properly and even the hide/autostart. What is not working is restoring the state  for those extra options on the publisher when editing an embedded map.